### PR TITLE
Pin actions to SHAs and publish to PyPI via OIDC

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -7,8 +7,11 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: develop
       - name: Reformat Code

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,23 +9,27 @@ on:
 jobs:
   create_release_zip:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: main
       - name: Create zip
         run: |
           zip -r ${{ inputs.release_tag }}.zip .* -x .git/**
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           path: ${{ inputs.release_tag }}.zip
 
   publish_release_zip:
     needs: create_release_zip
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/download-artifact@v4
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: create release
         run: |
           gh release create ${{ inputs.release_tag }} --generate-notes

--- a/.github/workflows/pypi-publish-workflow.yml
+++ b/.github/workflows/pypi-publish-workflow.yml
@@ -6,14 +6,16 @@ jobs:
   build:
     name: Build Job
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: 3.11
       - name: Build
         run: python setup.py sdist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           retention-days: 1
           name: dist
@@ -25,13 +27,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dist
           path: ${{ github.workspace }}/dist
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: ${{ vars.PYPI_USER }}
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          repository-url: https://pypi.org/project/FireEye-AWS/0.6.0.dev0/
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
Follow-up to the workflow hardening, kept separate from the feature work.

### Actions pinned to commit SHAs
`actions/checkout@v4` resolves to whatever that tag points at on the day the workflow runs. Whoever controls the tag controls what executes in a job holding your repository token. All five actions are pinned to a commit SHA with the version kept in a trailing comment:

- `actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4`
- `actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4`
- `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4`
- `actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4`
- `pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2`

Once this is on `main`, `sha_pinning_required` can be switched on for the repo so unpinned actions are rejected.

### PyPI publishing over OIDC
The publish job already asked for `id-token: write` but still authenticated with a long-lived `PYPI_API_TOKEN`. It also passed `repository-url: https://pypi.org/project/FireEye-AWS/0.6.0.dev0/`, which is a project page rather than an upload endpoint, so the job would have failed if anyone had run it.

Both are gone. `gh-action-pypi-publish` now uses Trusted Publishing, which mints a short-lived token per run and leaves no credential to steal.

**Before the next release**, add the Trusted Publisher on PyPI for project `FireEye-AWS`: owner `r0075h3ll`, repository `FireEye`, workflow `pypi-publish-workflow.yml`. Publishing fails without it. `PYPI_API_TOKEN` can be deleted from repository secrets afterwards.

### Per-job permissions
The repository default workflow token is now read-only, so every job declares what it needs: `contents: read` for the build jobs, `contents: write` for the release upload, `contents: write` plus `pull-requests: write` for the PR bot. Without this the release and PR workflows would break on their next run.

Nothing else changed. All three workflows are still `workflow_dispatch` only.