### PR TITLE
Bump version to 0.7.0 and read it from one place

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <div align="center">
 <img src="https://img.shields.io/badge/License-Apache%202.0-blue">
 <img src="https://img.shields.io/badge/Python-3.12-blue">
-<img src="https://img.shields.io/badge/Release-0.6.0 (dev)-green">
+<img src="https://img.shields.io/badge/Release-0.7.0-green">
 </div>
 
 \

--- a/fireeye/__init__.py
+++ b/fireeye/__init__.py
@@ -3,9 +3,11 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
+__version__ = "0.7.0"
+
 
 def banner():
-    print("\n\tFireEye v0.6.0-dev\n")
+    print(f"\n\tFireEye v{__version__}\n")
 
 
 banner()

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,15 @@ def read(fname):
     return open(os.path.join(this_dir, fname)).read()
 
 
+def get_version():
+    # Read it rather than import it, so setup.py does not pull in the package
+    for line in read(os.path.join("fireeye", "__init__.py")).splitlines():
+        if line.startswith("__version__"):
+            return line.split('"')[1]
+
+    raise RuntimeError("__version__ not found in fireeye/__init__.py")
+
+
 install_requires = [
     "boto3==1.35.54",
     "botocore==1.35.54",
@@ -24,7 +33,7 @@ install_requires = [
 
 setup(
     name="FireEye-AWS",
-    version="0.6.0-dev",
+    version=get_version(),
     author="Hardik Nanda",
     author_email="hnanda21@gmail.com",
     description="AWS Monitoring Toolkit",


### PR DESCRIPTION
Split out of #6 so the feature work and the release metadata land separately.

The version was written out in three files and had already drifted: `setup.py` and the banner said `0.6.0-dev`, the README badge said `0.6.0 (dev)`.

`fireeye.__version__` is now the only place it lives. `setup.py` reads that line out of the file rather than importing the package, because importing `fireeye` prints the banner and that would end up in build output.

0.7.0 rather than 0.6.0: #6 adds EC2 monitoring, Slack alerts and the search flags, which is a feature release, not a patch. Say the word if you would rather go to 1.0.0, it is a one-line change on this branch.

Checked: `python setup.py --version` prints `0.7.0` and `sdist` builds `fireeye_aws-0.7.0.tar.gz`.

The fourth occurrence, `repository-url: https://pypi.org/project/FireEye-AWS/0.6.0.dev0/` in the publish workflow, is deleted by #7, so this PR leaves it alone to avoid a conflict.