### PR TITLE
Fix failure handling: exit codes, escaping, argument validation

### DIFF
--- a/fireeye/__init__.py
+++ b/fireeye/__init__.py
@@ -7,7 +7,8 @@ __version__ = "0.7.0"
 
 
 def banner():
-    print(f"\n\tFireEye v{__version__}\n")
+    # stderr, so it does not end up in piped or redirected search results
+    print(f"\n\tFireEye v{__version__}\n", file=sys.stderr)
 
 
 banner()

--- a/fireeye/__main__.py
+++ b/fireeye/__main__.py
@@ -1,11 +1,23 @@
 import argparse
+import sys
+
+from botocore.exceptions import BotoCoreError, ClientError
 
 from fireeye.cloudwatch import CloudWatch, collect_logs, print_logs
-from fireeye.exceptions import CloudWatchLogException
+from fireeye.exceptions import ARNFormatError, CloudWatchLogException
 from fireeye.logger import logger
 from fireeye.slack import SlackApp, create_payload
 
-parser = argparse.ArgumentParser()
+
+def positive(value):
+    number = int(value)
+    if number < 1:
+        raise argparse.ArgumentTypeError(f"must be 1 or greater, got {value}")
+
+    return number
+
+
+parser = argparse.ArgumentParser(prog="fireeye")
 parser.add_argument(
     "--trace", help="Match a string/character", dest="to_trace", default="duration"
 )
@@ -29,10 +41,14 @@ parser.add_argument(
     action="store_true",
 )
 parser.add_argument(
-    "--days", help="How far back to search", dest="days", type=int, default=3
+    "--days", help="How far back to search", dest="days", type=positive, default=3
 )
 parser.add_argument(
-    "--limit", help="Maximum log lines to return", dest="limit", type=int, default=100
+    "--limit",
+    help="Maximum log lines to return",
+    dest="limit",
+    type=positive,
+    default=100,
 )
 parser.add_argument(
     "--slack-url",
@@ -42,10 +58,23 @@ parser.add_argument(
     const="",
     default=False,
 )
+parser.add_argument(
+    "--debug",
+    help="Print the full traceback when something fails",
+    dest="debug",
+    action="store_true",
+)
 
 args = parser.parse_args()
 if (args.arn or args.res_name) is False:
     exit(parser.print_help())
+
+
+def fail(message):
+    # exc_info only means something while an exception is being handled
+    logger.error(message, exc_info=args.debug and sys.exc_info()[0] is not None)
+
+    return 1
 
 
 def main():
@@ -64,23 +93,30 @@ def main():
         )
 
         logs = cloudwatch.fetch_logs(args.to_trace, regex=args.regex)
+    except (ARNFormatError, CloudWatchLogException) as e:
+        return fail(e)
+    except ClientError as e:
+        return fail(e.response.get("Error", {}).get("Message", e))
+    except BotoCoreError as e:
+        return fail(e)
 
-        print_logs(logs)
+    print_logs(logs)
 
-        if args.slack_webhook is not False:
-            slack_app = SlackApp(args.slack_webhook)
-            slack_app.send(
-                create_payload(ctx_info, cloudwatch.query, collect_logs(logs))
-            )
+    if logs["response"] is None:
+        return fail("CloudWatch returned no results field")
 
-        if logs["response"] is None:
-            raise CloudWatchLogException("Invalid Response")
+    if not logs["response"]:
+        logger.info("No matching log lines")
 
-        if not logs["response"]:
-            logger.info("No matching log lines")
-    except Exception as e:
-        logger.info(e, exc_info=True)
+    if args.slack_webhook is not False:
+        slack_app = SlackApp(args.slack_webhook)
+        if not slack_app.send(
+            create_payload(ctx_info, cloudwatch.query, collect_logs(logs))
+        ):
+            return fail("Slack alert was not delivered")
+
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/fireeye/cloudwatch.py
+++ b/fireeye/cloudwatch.py
@@ -3,23 +3,33 @@ import re
 import time
 
 from fireeye.aws import AWS
-from fireeye.exceptions import CloudWatchLogException
+from fireeye.exceptions import ARNFormatError, CloudWatchLogException
 from fireeye.logger import logger, dark_green, end
 
 INSTANCE_ID = re.compile(r"i-[0-9a-f]{8,17}\Z")
 
 
+def _fields(row: list):
+    """A result row as {field name: value}.
+
+    Rows come back as a list of {"field": ..., "value": ...}, and which fields
+    are present depends on the query, so index by name rather than position.
+    """
+    return {f.get("field"): f.get("value") for f in row}
+
+
 def print_logs(api_response: dict):
-    for resp in api_response["response"]:
-        logger.info(f"{dark_green}{resp[2].get('value')}{end}")
-        logger.info(f"{resp[1].get('value')}")
+    for row in api_response["response"] or []:
+        fields = _fields(row)
+        print(f"{dark_green}{fields.get('@logStream', '')}{end}")
+        print(fields.get("@message", ""))
 
 
 def collect_logs(api_response: dict):
     """Timestamp/message pairs, as a list so identical timestamps are kept."""
     return [
-        (resp[0].get("value"), resp[1].get("value"))
-        for resp in api_response["response"] or []
+        (_fields(row).get("@timestamp"), _fields(row).get("@message"))
+        for row in api_response["response"] or []
     ]
 
 
@@ -31,18 +41,35 @@ def time_diff(days: int = 3):
 
 
 def parse_arn(arn: str):  # Filter resource name from un-qualified lambda arn
-    logger.info("Parsing ARN")
-    try:
-        if arn.split(":")[2] in ("lambda", "ec2"):
-            return arn.split(":")[-1].split("/")[-1]
-    except IndexError:
-        logger.info("Failed to parse ARN")
+    if not arn.startswith("arn:"):
+        return arn
 
-    return arn
+    logger.info("Parsing ARN")
+    parts = arn.split(":")
+    if len(parts) < 6:
+        raise ARNFormatError(f"Not a well formed ARN: {arn}")
+
+    service = parts[2]
+    if service not in ("lambda", "ec2"):
+        raise ARNFormatError(
+            f"FireEye reads Lambda and EC2 logs, but this ARN is for {service}: {arn}"
+        )
+
+    return parts[-1].split("/")[-1]
 
 
 def is_instance_id(name: str):
     return bool(INSTANCE_ID.match(name))
+
+
+def quote(to_trace: str):
+    """Escape a search term for a CloudWatch string literal.
+
+    Without this a term containing a double quote closes the literal early and
+    the rest is parsed as query syntax, which is how searching for something
+    like {"status": 500} ended up as a MalformedQueryException.
+    """
+    return to_trace.replace("\\", "\\\\").replace('"', '\\"')
 
 
 def build_query(to_trace: str, regex: bool = False, log_stream: str = ""):
@@ -52,7 +79,7 @@ def build_query(to_trace: str, regex: bool = False, log_stream: str = ""):
     CloudWatch regex literal, so `--regex '(?i)timeout|error'` covers
     case-insensitive and multi-term searches.
     """
-    match = f"/{to_trace}/" if regex else f'"{to_trace}"'
+    match = f"/{to_trace}/" if regex else f'"{quote(to_trace)}"'
     query = f"fields @timestamp, @message, @logStream | filter @message like {match}"
 
     if log_stream:
@@ -124,6 +151,15 @@ class CloudWatch(AWS):
         logs_client = self.aws_session.client("logs")
         self.query = build_query(to_trace, regex, self.log_stream)
 
+        # Log what is about to run, not what ran, so a rejected query still
+        # shows the group and query string that caused it.
+        logger.info(f"Query String :: {self.query}")
+        logger.info(
+            f"Time Range :: {datetime.datetime.fromtimestamp(self.start_time)} to "
+            f"{datetime.datetime.fromtimestamp(self.end_time)}"
+        )
+        logger.info(f"Log Group :: {self.log_group}")
+
         query_id = logs_client.start_query(
             logGroupName=self.log_group,
             startTime=self.start_time,
@@ -131,13 +167,6 @@ class CloudWatch(AWS):
             queryString=self.query,
             limit=self.limit,
         )
-
-        logger.info(f"Query String :: {self.query}")
-        logger.info(
-            f"Time Range :: {datetime.datetime.fromtimestamp(self.start_time)} to "
-            f"{datetime.datetime.fromtimestamp(self.end_time)}"
-        )
-        logger.info(f"Log Group :: {self.log_group}\n")
 
         query_results = self._wait_for_results(logs_client, query_id.get("queryId"))
 

--- a/fireeye/logger.py
+++ b/fireeye/logger.py
@@ -1,16 +1,30 @@
 import logging
 import sys
 
-# logging.basicConfig(format='%(asctime)s %(name)s %(levelname)s:%(message)s')
-red = "\033[31m"
-green = "\033[32m"
-end = "\033[00m"
-dark_green = "\033[92m"
+# Escape codes only when the stream is a terminal, so piped output and log
+# files do not fill up with them.
+if sys.stdout.isatty():
+    end = "\033[00m"
+    dark_green = "\033[92m"
+else:
+    end = ""
+    dark_green = ""
+
+if sys.stderr.isatty():
+    red = "\033[31m"
+    green = "\033[32m"
+    reset = "\033[00m"
+else:
+    red = ""
+    green = ""
+    reset = ""
 
 formatter = logging.Formatter(
-    f"{red}%(asctime)s - %(name)s{end} :: {green}%(levelname)s - %(message)s{end}"
+    f"{red}%(asctime)s - %(name)s{reset} :: {green}%(levelname)s - %(message)s{reset}"
 )
-handler = logging.StreamHandler(sys.stdout)
+# Diagnostics go to stderr. Matched log lines are printed to stdout, so the
+# two can be separated by whoever is calling.
+handler = logging.StreamHandler(sys.stderr)
 handler.setFormatter(formatter)
 
 logger = logging.getLogger(__name__)

--- a/fireeye/slack.py
+++ b/fireeye/slack.py
@@ -79,17 +79,17 @@ class SlackApp:
 
     def send(self, payload: dict):
         if not self.url:
-            logger.info("No Slack webhook URL, skipping alert")
+            logger.error("No Slack webhook URL set, alert not sent")
             return False
 
         try:
             resp = http.request("POST", self.url, json=payload, timeout=10, retries=1)
         except Exception as e:
-            logger.info(e)
+            logger.error(f"Slack alert failed: {e}")
             return False
 
         if resp.status != 200:
-            logger.info(f"Slack returned {resp.status}: {resp.data.decode(errors='replace')}")
+            logger.error(f"Slack returned {resp.status}: {resp.data.decode(errors='replace')}")
             return False
 
         logger.info("Notification sent successfully!")

--- a/test_fireeye.py
+++ b/test_fireeye.py
@@ -1,6 +1,14 @@
 """Self-check for the pure helpers. Run: python3 test_fireeye.py"""
 
-from fireeye.cloudwatch import build_query, collect_logs, is_instance_id, parse_arn
+from fireeye.cloudwatch import (
+    build_query,
+    collect_logs,
+    is_instance_id,
+    parse_arn,
+    print_logs,
+    quote,
+)
+from fireeye.exceptions import ARNFormatError
 from fireeye.slack import create_payload, format_matches
 
 
@@ -8,6 +16,13 @@ def test_parse_arn():
     assert parse_arn("arn:aws:lambda:eu-west-1:123456789012:function:biller") == "biller"
     assert parse_arn("arn:aws:ec2:eu-west-1:123456789012:instance/i-0abc1234") == "i-0abc1234"
     assert parse_arn("biller") == "biller"
+
+    for bad in ("arn:aws:s3:::my-bucket", "arn:aws:lambda"):
+        try:
+            parse_arn(bad)
+            raise AssertionError(f"{bad} should have been rejected")
+        except ARNFormatError:
+            pass
 
 
 def test_is_instance_id():
@@ -27,8 +42,33 @@ def test_build_query():
     assert '@logStream like "i-0abc1234"' in scoped
 
 
+def test_quote():
+    assert quote('{"status": 500}') == '{\\"status\\": 500}'
+    assert quote("back\\slash") == "back\\\\slash"
+
+    # a term with a quote in it must not close the string literal early
+    query = build_query('a" | stats count() as c | filter c > 0 | filter @message like "')
+    assert query.count('like "') == 1
+
+
+def test_rows_indexed_by_name():
+    # @ptr is always returned and the field order is not guaranteed
+    row = [
+        {"field": "@ptr", "value": "xyz"},
+        {"field": "@message", "value": "boom"},
+        {"field": "@logStream", "value": "stream"},
+        {"field": "@timestamp", "value": "12:00"},
+    ]
+    assert collect_logs({"response": [row]}) == [("12:00", "boom")]
+    print_logs({"response": [row]})  # must not raise on an unexpected field order
+
+
 def test_collect_logs():
-    event = [{"value": "12:00"}, {"value": "boom"}, {"value": "stream"}]
+    event = [
+        {"field": "@timestamp", "value": "12:00"},
+        {"field": "@message", "value": "boom"},
+        {"field": "@logStream", "value": "stream"},
+    ]
     assert collect_logs({"response": [event, event]}) == [("12:00", "boom")] * 2
     assert collect_logs({"response": None}) == []
 


### PR DESCRIPTION
Everything here came out of running the CLI the way a user would, from a fresh clone installed per the README. The features worked; the failure paths did not.

### Exit status was always 0
Verified against five different failures: missing credentials, missing region, a log group that does not exist, access denied, and a rejected query. All exited 0. Anything running this on a schedule would report success forever.

`main()` returns a status now. Errors print as one line instead of a traceback; `--debug` brings the traceback back when you want it.

```
$ fireeye --trace Bill --resource-name lambda_name; echo $?
ERROR - Log group '/aws/lambda/lambda_name' does not exist for account ID '...'
1
```

### Output streams were mixed
Diagnostics, tracebacks and the banner all went to stdout, so `fireeye ... | grep` pulled tracebacks into the results and `2>/dev/null` silenced nothing. Diagnostics and the banner are on stderr now, matched log lines on stdout. Colour codes are only emitted to a terminal, so redirected output is no longer full of escape sequences.

### A quote in the search term broke the query
`--trace` was interpolated into the query unescaped, so the term closed the string literal and the remainder was parsed as query syntax:

```
$ fireeye --trace '{"status": 500}' --resource-name <fn>
MalformedQueryException: unexpected symbol found status at line 1 and position 149
```

Terms are escaped now, and that search runs. This was not only a crafted-input problem: JSON fragments are an obvious thing to search Lambda logs for.

### Result rows were read by position
`resp[1]` and `resp[2]` assume a fixed field order. A query returning a different shape raised `IndexError: list index out of range`. Rows are indexed by field name instead.

### --days and --limit accepted nonsense
`--days 0` built a zero-width window and quietly returned nothing. `--days -5` and `--limit 0` were rejected by AWS after a round trip. Both are validated before the call, and argparse exits 2 with a readable message.

### Slack failures were invisible
A connection refused and a redirect loop were both logged at INFO with exit 0. An alerting tool that silently fails to alert is the worst version of this. They are errors now and set the exit status. `--slack-url` with no webhook configured also fails rather than skipping quietly.

### Smaller things
The query string and log group are logged before `start_query`, not after, so a rejected query shows what was attempted. ARNs for other services are rejected with a clear message instead of surfacing as `AccessDeniedException ... StartQuery on resources my-bucket`.

### Verified
Fresh clone, `pip install .`, then re-ran every failure from the critique against a real account: exit 1 with a one-line error on each, exit 2 on bad arguments, exit 0 on success and on a delivered Slack alert. The self-check grew cases for escaping, field-name indexing and ARN rejection: `python3 test_fireeye.py`, 8 pass.