### PR TITLE
Fix ARN qualifiers, log group input, Slack block size

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,31 @@ pip install .
 pip install FireEye-AWS
 ```
 
+### Credentials
+
+FireEye uses your existing AWS configuration. It reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and
+`AWS_DEFAULT_REGION` if they are set, and otherwise falls back to whatever boto3 finds: `~/.aws/credentials`,
+a profile, or an instance role.
+
+A region is required. Without one you get `You must specify a region.` and exit status 1.
+
+The IAM permissions needed are `logs:StartQuery`, `logs:GetQueryResults`, `logs:StopQuery` and
+`sts:GetCallerIdentity`.
+
 ### Features
 
 ##### Monitor Lambda functions w/ CloudWatch Logs Insights
 
 ```bash
 fireeye --trace Bill --resource-name lambda_name
+```
+
+`--resource-name` also accepts a log group directly, and `--arn` accepts a Lambda or EC2 ARN,
+qualified ones included:
+
+```bash
+fireeye --trace Bill --resource-name /aws/lambda/lambda_name
+fireeye --trace Bill --arn arn:aws:lambda:us-east-1:123456789012:function:lambda_name:PROD
 ```
 
 ##### Monitor EC2 instances
@@ -57,7 +76,9 @@ fireeye --trace '(?i)error|timeout' --resource-name lambda_name --regex --days 7
 ```
 
 `--days` sets how far back to look (default 3) and `--limit` caps the number of lines
-returned (default 100).
+returned (default 100). Both must be 1 or greater.
+
+Without `--trace` the search term defaults to `duration`.
 
 ##### Get alerts on a Slack channel
 
@@ -68,6 +89,42 @@ fireeye --trace Bill --resource-name lambda_name --slack-url
 # or pass it inline
 fireeye --trace Bill --resource-name lambda_name --slack-url https://slack-webhook-url
 ```
+
+An alert that cannot be delivered is an error, not a warning: if the webhook is unreachable, returns a
+non-200, or is not set at all, FireEye exits 1. Long results are trimmed to fit Slack's message limit and
+the remainder is counted in a trailing line.
+
+### Output and exit status
+
+Matched log lines go to stdout. Everything else, banner and progress and errors, goes to stderr, so
+results can be piped or redirected on their own:
+
+```bash
+fireeye --trace ERROR --resource-name lambda_name > matches.txt
+```
+
+| Status | Meaning |
+| --- | --- |
+| 0 | Ran successfully, whether or not anything matched |
+| 1 | Failed: no credentials, no region, missing log group, access denied, bad query, Slack alert not delivered |
+| 2 | Bad arguments |
+
+Errors print as a single line. Add `--debug` for the full traceback.
+
+This makes it usable from cron:
+
+```bash
+0 * * * * fireeye --trace ERROR --resource-name lambda_name --slack-url || logger fireeye failed
+```
+
+### Development
+
+```bash
+python3 test_fireeye.py
+```
+
+No test framework needed. The checks cover ARN parsing, query building and escaping, result handling,
+and the Slack payload, and they make no AWS calls.
 
 ### To Do
 

--- a/fireeye/__main__.py
+++ b/fireeye/__main__.py
@@ -66,8 +66,9 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
-if (args.arn or args.res_name) is False:
-    exit(parser.print_help())
+if not (args.arn or args.res_name):
+    parser.print_help()
+    sys.exit(2)
 
 
 def fail(message):

--- a/fireeye/cloudwatch.py
+++ b/fireeye/cloudwatch.py
@@ -6,7 +6,7 @@ from fireeye.aws import AWS
 from fireeye.exceptions import ARNFormatError, CloudWatchLogException
 from fireeye.logger import logger, dark_green, end
 
-INSTANCE_ID = re.compile(r"i-[0-9a-f]{8,17}\Z")
+INSTANCE_ID = re.compile(r"i-[0-9a-f]{8,17}\Z", re.IGNORECASE)
 
 
 def _fields(row: list):
@@ -55,6 +55,15 @@ def parse_arn(arn: str):  # Filter resource name from un-qualified lambda arn
             f"FireEye reads Lambda and EC2 logs, but this ARN is for {service}: {arn}"
         )
 
+    if service == "lambda":
+        # arn:aws:lambda:<region>:<account>:function:<name>[:<alias or version>]
+        # The last segment is the qualifier on a qualified ARN, not the name.
+        if len(parts) < 7:
+            raise ARNFormatError(f"No function name in ARN: {arn}")
+
+        return parts[6]
+
+    # arn:aws:ec2:<region>:<account>:instance/<instance id>
     return parts[-1].split("/")[-1]
 
 
@@ -100,7 +109,11 @@ class CloudWatch(AWS):
         self.start_time, self.end_time = time_diff(days)
         self.query = ""
 
-        if is_instance_id(self.resource_name):
+        if self.resource_name.startswith("/"):
+            # Someone passed the log group itself as the resource name
+            self.log_group = log_group or self.resource_name
+            self.log_stream = ""
+        elif is_instance_id(self.resource_name):
             # EC2 log groups are named by whoever configured the CloudWatch
             # agent, so there is nothing sensible to guess here.
             if not log_group:

--- a/fireeye/slack.py
+++ b/fireeye/slack.py
@@ -7,13 +7,28 @@ from fireeye.logger import logger
 http = urllib3.PoolManager()
 
 
-def format_matches(matches: list, max_lines: int = 20):
+# Slack rejects a section whose text runs past 3000 characters, and typical
+# Lambda REPORT lines blow through that well before max_lines is reached.
+BLOCK_LIMIT = 2900
+
+
+def format_matches(matches: list, max_lines: int = 20, limit: int = BLOCK_LIMIT):
     if not matches:
         return "No matching log lines."
 
-    lines = [f"{stamp} {message}" for stamp, message in matches[:max_lines]]
-    if len(matches) > max_lines:
-        lines.append(f"... and {len(matches) - max_lines} more")
+    lines = []
+    used = 0
+    for stamp, message in matches[:max_lines]:
+        line = f"{stamp} {message}"
+        if used + len(line) > limit:
+            break
+
+        lines.append(line)
+        used += len(line) + 1
+
+    dropped = len(matches) - len(lines)
+    if dropped > 0:
+        lines.append(f"... and {dropped} more")
 
     return "\n".join(lines)
 

--- a/test_fireeye.py
+++ b/test_fireeye.py
@@ -17,6 +17,12 @@ def test_parse_arn():
     assert parse_arn("arn:aws:ec2:eu-west-1:123456789012:instance/i-0abc1234") == "i-0abc1234"
     assert parse_arn("biller") == "biller"
 
+    # a qualified ARN ends in the alias or version, not the function name
+    assert (
+        parse_arn("arn:aws:lambda:eu-west-1:123456789012:function:biller:PROD")
+        == "biller"
+    )
+
     for bad in ("arn:aws:s3:::my-bucket", "arn:aws:lambda"):
         try:
             parse_arn(bad)
@@ -71,6 +77,16 @@ def test_collect_logs():
     ]
     assert collect_logs({"response": [event, event]}) == [("12:00", "boom")] * 2
     assert collect_logs({"response": None}) == []
+
+
+def test_format_matches_stays_under_slack_limit():
+    from fireeye.slack import BLOCK_LIMIT
+
+    long_line = "REPORT RequestId: 1c6a91a9\tDuration: 514.37 ms\t" + "x" * 120
+    text = format_matches([(f"12:0{i}", long_line) for i in range(20)])
+
+    assert len(text) <= BLOCK_LIMIT + 40  # the "... and N more" line
+    assert text.endswith("more")
 
 
 def test_format_matches():


### PR DESCRIPTION
A second pass of adversarial testing against a real account, after #10. Five more bugs, all reachable by a user doing something reasonable.

### Qualified Lambda ARNs resolved to the alias
`parse_arn` took the last colon-separated segment. On a qualified ARN that is the alias or version, not the function:

```
--arn arn:aws:lambda:us-east-1:<acct>:function:<fn>:PROD
→ Log Group :: /aws/lambda/PROD
→ ResourceNotFoundException
```

The function name sits at a fixed position in a Lambda ARN, so it is read there. EC2 ARNs keep the `instance/<id>` handling.

### Passing a log group to --resource-name doubled the prefix
`--resource-name /aws/lambda/foo` is an easy thing to do when you copied the name out of the console:

```
→ Log Group :: /aws/lambda//aws/lambda/foo
```

A value starting with `/` is now treated as the log group.

### Slack alerts on a busy function were being refused
Slack caps a section's text at 3000 characters. Twenty typical Lambda REPORT lines measured 3801, and `format_matches` only capped the line count, not the length. The alert would have been rejected as `invalid_blocks` exactly when there was the most to report. Lines are now added until the character budget runs out, with the remainder counted in the `... and N more` line.

### An empty --resource-name reached AWS
`if (args.arn or args.res_name) is False` does not catch `""`, so `--resource-name ''` queried `/aws/lambda/`. Now prints usage and exits 2.

### Instance IDs are matched case insensitively
`I-0ABC1234` was treated as a Lambda name and looked up as `/aws/lambda/I-0ABC1234`. It is recognised as EC2 now, so it asks for `--log-group` like any other instance.

### Verified
Each case re-run against a real log group after the fix: the qualified ARN returns real log lines, the log-group form resolves correctly, the empty name exits 2, the uppercase instance ID asks for a log group, and the happy path still exits 0. Self-check is at 9 cases with the qualified ARN and the Slack length budget added.