### PR TITLE
Keep fireeye.aws_lambda importable

### DIFF
--- a/fireeye/aws_lambda.py
+++ b/fireeye/aws_lambda.py
@@ -1,0 +1,26 @@
+"""Deprecated alias for :mod:`fireeye.cloudwatch`.
+
+The module was renamed when EC2 support arrived, since the class in it was
+never Lambda specific. This keeps `from fireeye.aws_lambda import ...` working
+for anyone who wrote against an earlier release.
+"""
+
+import warnings
+
+from fireeye.cloudwatch import (  # noqa: F401
+    CloudWatch,
+    build_query,
+    collect_logs,
+    is_instance_id,
+    parse_arn,
+    print_logs,
+    quote,
+    time_diff,
+)
+
+warnings.warn(
+    "fireeye.aws_lambda has moved to fireeye.cloudwatch and will be removed in a "
+    "future release",
+    DeprecationWarning,
+    stacklevel=2,
+)

--- a/fireeye/aws_lambda.py
+++ b/fireeye/aws_lambda.py
@@ -3,6 +3,9 @@
 The module was renamed when EC2 support arrived, since the class in it was
 never Lambda specific. This keeps `from fireeye.aws_lambda import ...` working
 for anyone who wrote against an earlier release.
+
+The warning is raised at import, so Python's default filters show it once per
+process rather than on every attribute access.
 """
 
 import warnings
@@ -18,9 +21,20 @@ from fireeye.cloudwatch import (  # noqa: F401
     time_diff,
 )
 
+__all__ = [
+    "CloudWatch",
+    "build_query",
+    "collect_logs",
+    "is_instance_id",
+    "parse_arn",
+    "print_logs",
+    "quote",
+    "time_diff",
+]
+
 warnings.warn(
-    "fireeye.aws_lambda has moved to fireeye.cloudwatch and will be removed in a "
-    "future release",
+    "fireeye.aws_lambda has moved to fireeye.cloudwatch and will be removed in "
+    "1.0.0",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/test_fireeye.py
+++ b/test_fireeye.py
@@ -223,6 +223,16 @@ def test_stop_failure_is_warned_not_hidden():
         logger.removeHandler(handler)
 
     assert any(r.levelno >= logging.WARNING for r in records), records
+def test_old_module_path_still_works():
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        from fireeye.aws_lambda import CloudWatch, parse_arn as old_parse_arn
+
+    assert CloudWatch.__module__ == "fireeye.cloudwatch"
+    assert old_parse_arn("biller") == "biller"
+    assert any(w.category is DeprecationWarning for w in caught)
 
 
 if __name__ == "__main__":

--- a/test_fireeye.py
+++ b/test_fireeye.py
@@ -224,15 +224,30 @@ def test_stop_failure_is_warned_not_hidden():
 
     assert any(r.levelno >= logging.WARNING for r in records), records
 def test_old_module_path_still_works():
+    import sys
     import warnings
+
+    import fireeye.cloudwatch
+
+    # a previous import would have cached the module and swallowed the warning
+    sys.modules.pop("fireeye.aws_lambda", None)
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        from fireeye.aws_lambda import CloudWatch, parse_arn as old_parse_arn
+        import fireeye.aws_lambda as old
 
-    assert CloudWatch.__module__ == "fireeye.cloudwatch"
-    assert old_parse_arn("biller") == "biller"
-    assert any(w.category is DeprecationWarning for w in caught)
+    assert old.CloudWatch is fireeye.cloudwatch.CloudWatch, "must be the same class"
+    assert old.parse_arn is fireeye.cloudwatch.parse_arn
+    assert (
+        old.parse_arn("arn:aws:lambda:eu-west-1:123456789012:function:biller")
+        == "biller"
+    )
+
+    deprecations = [w for w in caught if w.category is DeprecationWarning]
+    assert deprecations, "importing the old path must warn"
+    assert "1.0.0" in str(deprecations[0].message), "the warning must name a removal version"
+
+    assert set(old.__all__) <= set(dir(fireeye.cloudwatch))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`fireeye/aws_lambda.py` became `fireeye/cloudwatch.py` in #6, because the `CloudWatch` class in it was never Lambda specific. That breaks `from fireeye.aws_lambda import ...` for anyone who wrote against an earlier release of the published package.

The old path re-exports from the new module and raises a `DeprecationWarning` on import:

```
$ python -W always -c 'from fireeye.aws_lambda import CloudWatch'
DeprecationWarning: fireeye.aws_lambda has moved to fireeye.cloudwatch and will be removed in a future release
```

`CloudWatch.lambda_logs` already aliases `fetch_logs`, so code written against the old module keeps working end to end, not just at import time.

Verified from an installed build: the old import resolves, `CloudWatch.__module__` is `fireeye.cloudwatch`, and the warning fires once. Self-check is at 10 cases.