### PR TITLE
Stop the query on interrupt or timeout, exit 130 on Ctrl-C

### DIFF
--- a/fireeye/__main__.py
+++ b/fireeye/__main__.py
@@ -100,6 +100,10 @@ def main():
         return fail(e.response.get("Error", {}).get("Message", e))
     except BotoCoreError as e:
         return fail(e)
+    except KeyboardInterrupt:
+        logger.error("Interrupted")
+
+        return 130
 
     print_logs(logs)
 

--- a/fireeye/cloudwatch.py
+++ b/fireeye/cloudwatch.py
@@ -139,26 +139,46 @@ class CloudWatch(AWS):
             "res_name": self.resource_name,
         }
 
+    def _stop(self, logs_client, query_id):
+        # A query left running keeps scanning, and Insights bills scanned data
+        # whether or not anyone reads the result.
+        try:
+            logs_client.stop_query(queryId=query_id)
+        except Exception as e:  # already finished, or the stop itself failed
+            logger.info(f"Could not stop query {query_id}: {e}")
+
     def _wait_for_results(self, logs_client, query_id):
         deadline = time.monotonic() + self.wait
 
         while True:
-            results = logs_client.get_query_results(queryId=query_id)
+            try:
+                results = logs_client.get_query_results(queryId=query_id)
+            except KeyboardInterrupt:
+                self._stop(logs_client, query_id)
+                raise
+
             status = results.get("status")
 
             if status not in ("Scheduled", "Running"):
                 if status != "Complete":
-                    raise CloudWatchLogException(f"Query {status.lower()}")
+                    raise CloudWatchLogException(
+                        f"Query {status.lower()}. CloudWatch gives no reason for "
+                        f"this, so retry or narrow the time range."
+                    )
 
                 return results
 
             if time.monotonic() >= deadline:
-                logs_client.stop_query(queryId=query_id)
+                self._stop(logs_client, query_id)
                 raise CloudWatchLogException(
                     f"Query did not finish within {self.wait}s"
                 )
 
-            time.sleep(1)
+            try:
+                time.sleep(1)
+            except KeyboardInterrupt:
+                self._stop(logs_client, query_id)
+                raise
 
     def fetch_logs(self, to_trace, regex=False):
         logs_client = self.aws_session.client("logs")

--- a/fireeye/cloudwatch.py
+++ b/fireeye/cloudwatch.py
@@ -145,40 +145,36 @@ class CloudWatch(AWS):
         try:
             logs_client.stop_query(queryId=query_id)
         except Exception as e:  # already finished, or the stop itself failed
-            logger.info(f"Could not stop query {query_id}: {e}")
+            # warning, not info: whoever just hit Ctrl-C is not reading debug logs
+            logger.warning(f"Could not stop query {query_id}: {e}")
 
     def _wait_for_results(self, logs_client, query_id):
         deadline = time.monotonic() + self.wait
 
-        while True:
-            try:
+        try:
+            while True:
                 results = logs_client.get_query_results(queryId=query_id)
-            except KeyboardInterrupt:
-                self._stop(logs_client, query_id)
-                raise
+                status = results.get("status")
 
-            status = results.get("status")
+                if status not in ("Scheduled", "Running"):
+                    if status != "Complete":
+                        raise CloudWatchLogException(
+                            f"Query {status.lower()}. CloudWatch gives no reason "
+                            f"for this, so retry or narrow the time range."
+                        )
 
-            if status not in ("Scheduled", "Running"):
-                if status != "Complete":
+                    return results
+
+                if time.monotonic() >= deadline:
+                    self._stop(logs_client, query_id)
                     raise CloudWatchLogException(
-                        f"Query {status.lower()}. CloudWatch gives no reason for "
-                        f"this, so retry or narrow the time range."
+                        f"Query did not finish within {self.wait}s"
                     )
 
-                return results
-
-            if time.monotonic() >= deadline:
-                self._stop(logs_client, query_id)
-                raise CloudWatchLogException(
-                    f"Query did not finish within {self.wait}s"
-                )
-
-            try:
                 time.sleep(1)
-            except KeyboardInterrupt:
-                self._stop(logs_client, query_id)
-                raise
+        except KeyboardInterrupt:
+            self._stop(logs_client, query_id)
+            raise
 
     def fetch_logs(self, to_trace, regex=False):
         logs_client = self.aws_session.client("logs")

--- a/test_fireeye.py
+++ b/test_fireeye.py
@@ -1,6 +1,7 @@
 """Self-check for the pure helpers. Run: python3 test_fireeye.py"""
 
 from fireeye.cloudwatch import (
+    CloudWatch,
     build_query,
     collect_logs,
     is_instance_id,
@@ -8,7 +9,7 @@ from fireeye.cloudwatch import (
     print_logs,
     quote,
 )
-from fireeye.exceptions import ARNFormatError
+from fireeye.exceptions import ARNFormatError, CloudWatchLogException
 from fireeye.slack import create_payload, format_matches
 
 
@@ -106,6 +107,73 @@ def test_create_payload():
     body = payload["blocks"][-1]["text"]["text"]
     assert "boom" in body and "fields @timestamp" in body
     assert "Resource ARN: none" in str(payload)
+
+
+class FakeLogs:
+    """Enough of the CloudWatch Logs client to drive the polling loop."""
+
+    def __init__(self, statuses, interrupt_on=None):
+        self.statuses = list(statuses)
+        self.interrupt_on = interrupt_on
+        self.calls = 0
+        self.stopped = []
+
+    def get_query_results(self, queryId):
+        self.calls += 1
+        if self.calls == self.interrupt_on:
+            raise KeyboardInterrupt
+
+        status = self.statuses.pop(0) if self.statuses else "Running"
+
+        return {"status": status, "results": [] if status == "Complete" else None}
+
+    def stop_query(self, queryId):
+        self.stopped.append(queryId)
+
+
+def _waiter(wait=60):
+    watcher = CloudWatch.__new__(CloudWatch)  # no AWS session, no credentials
+    watcher.wait = wait
+
+    return watcher
+
+
+def test_polling_waits_then_returns():
+    logs = FakeLogs(["Scheduled", "Running", "Complete"])
+    assert _waiter()._wait_for_results(logs, "q1")["status"] == "Complete"
+    assert logs.calls == 3
+    assert logs.stopped == []
+
+
+def test_failed_and_cancelled_queries_raise():
+    for status in ("Failed", "Cancelled", "Timeout"):
+        try:
+            _waiter()._wait_for_results(FakeLogs([status]), "q1")
+            raise AssertionError(f"{status} should have raised")
+        except CloudWatchLogException as e:
+            assert status.lower() in str(e)
+
+
+def test_timeout_stops_the_query():
+    logs = FakeLogs(["Running"])
+    try:
+        _waiter(wait=0)._wait_for_results(logs, "q1")
+        raise AssertionError("should have timed out")
+    except CloudWatchLogException as e:
+        assert "did not finish" in str(e)
+
+    assert logs.stopped == ["q1"], "a timed out query must be stopped"
+
+
+def test_interrupt_stops_the_query():
+    logs = FakeLogs(["Running", "Running"], interrupt_on=2)
+    try:
+        _waiter()._wait_for_results(logs, "q1")
+        raise AssertionError("should have propagated KeyboardInterrupt")
+    except KeyboardInterrupt:
+        pass
+
+    assert logs.stopped == ["q1"], "an interrupted query must be stopped"
 
 
 if __name__ == "__main__":

--- a/test_fireeye.py
+++ b/test_fireeye.py
@@ -125,7 +125,8 @@ class FakeLogs:
 
         status = self.statuses.pop(0) if self.statuses else "Running"
 
-        return {"status": status, "results": [] if status == "Complete" else None}
+        # the real API returns an empty list while a query is in progress
+        return {"status": status, "results": []}
 
     def stop_query(self, queryId):
         self.stopped.append(queryId)
@@ -174,6 +175,54 @@ def test_interrupt_stops_the_query():
         pass
 
     assert logs.stopped == ["q1"], "an interrupted query must be stopped"
+
+
+def test_interrupt_during_the_sleep_stops_the_query():
+    import fireeye.cloudwatch as cloudwatch
+
+    def interrupting_sleep(seconds):
+        raise KeyboardInterrupt
+
+    logs = FakeLogs(["Running"])
+    slept = cloudwatch.time.sleep
+    cloudwatch.time.sleep = interrupting_sleep
+    try:
+        _waiter()._wait_for_results(logs, "q1")
+        raise AssertionError("should have propagated KeyboardInterrupt")
+    except KeyboardInterrupt:
+        pass
+    finally:
+        cloudwatch.time.sleep = slept
+
+    assert logs.stopped == ["q1"], "an interrupt between polls must stop the query"
+
+
+def test_stop_failure_is_warned_not_hidden():
+    import logging
+
+    class Unstoppable(FakeLogs):
+        def stop_query(self, queryId):
+            raise RuntimeError("credentials expired")
+
+    records = []
+
+    class Capture(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    from fireeye.logger import logger
+
+    handler = Capture()
+    logger.addHandler(handler)
+    try:
+        _waiter(wait=0)._wait_for_results(Unstoppable(["Running"]), "q1")
+        raise AssertionError("should have timed out")
+    except CloudWatchLogException:
+        pass
+    finally:
+        logger.removeHandler(handler)
+
+    assert any(r.levelno >= logging.WARNING for r in records), records
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two of the four untested paths from the last review, both coverable without any new resources.

### Ctrl-C left a query running in CloudWatch
Interrupting during polling printed a traceback and walked away from a running Insights query. That is not only untidy: Insights bills scanned data whether or not anyone reads the result, so an abandoned query keeps costing after the process has exited.

The poll loop now calls `stop_query` when interrupted, and the CLI exits 130 with one line instead of a traceback:

```
$ fireeye --trace Duration --resource-name <fn>   # SIGINT during polling
ERROR - Interrupted
exit 130
```

Verified against a real query, and `describe_queries` afterwards shows 0 running and 0 scheduled.

### Timeout now stops the query too
The 60s timeout already called `stop_query`, but a failure in that call would have masked the original timeout error. Both paths go through a helper that logs and moves on.

### Failed and Cancelled queries say what to do
CloudWatch gives no reason for either, so the message suggests retrying or narrowing the time range rather than just restating the status.

### Coverage without AWS
The self-check grew a stub Logs client, which makes the branches reachable that a real account will not produce on demand: `Scheduled` then `Running` then `Complete`, each of `Failed`/`Cancelled`/`Timeout`, the wait timeout, and an interrupt mid-poll. The last two assert that `stop_query` was actually called. No AWS calls, no credentials needed. 13 checks pass.