### PR TITLE
Add the alert send time in UTC to Slack notifications

### DIFF
--- a/fireeye/slack.py
+++ b/fireeye/slack.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 
 import urllib3
@@ -31,6 +32,11 @@ def format_matches(matches: list, max_lines: int = 20, limit: int = BLOCK_LIMIT)
         lines.append(f"... and {dropped} more")
 
     return "\n".join(lines)
+
+
+def utc_now():
+    # UTC, so an alert read in another timezone still says when it fired
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
 def create_payload(info: dict, query: str, matches: list):
@@ -70,6 +76,12 @@ def create_payload(info: dict, query: str, matches: list):
                             {
                                 "type": "text",
                                 "text": f"Resource Name: {resource_name}",
+                                "style": {"bold": True},
+                            },
+                            {"type": "text", "text": "\n"},
+                            {
+                                "type": "text",
+                                "text": f"Alert Time: {utc_now()}",
                                 "style": {"bold": True},
                             },
                         ],

--- a/fireeye/slack.py
+++ b/fireeye/slack.py
@@ -39,7 +39,13 @@ def utc_now():
     return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
-def create_payload(info: dict, query: str, matches: list):
+def create_payload(info: dict, query: str, matches: list, alert_time: str = ""):
+    """Build the Slack message.
+
+    `alert_time` defaults to now. It is stamped when the payload is assembled,
+    which is a moment before the post, not after any retry.
+    """
+    alert_time = alert_time or utc_now()
     account_id = info.get("acc_id", "none")
     resource_arn = info.get("resource_arn") or "none"
     resource_name = info.get("res_name", "none")
@@ -81,7 +87,7 @@ def create_payload(info: dict, query: str, matches: list):
                             {"type": "text", "text": "\n"},
                             {
                                 "type": "text",
-                                "text": f"Alert Time: {utc_now()}",
+                                "text": f"Alert Time: {alert_time}",
                                 "style": {"bold": True},
                             },
                         ],

--- a/test_fireeye.py
+++ b/test_fireeye.py
@@ -109,7 +109,13 @@ def test_create_payload():
     assert "Resource ARN: none" in str(payload)
 
     # the alert carries its own send time, in UTC, not the log line timestamps
-    assert f"Alert Time: {utc_now()[:13]}" in str(payload)
+    stamped = create_payload(
+        {"acc_id": "123", "res_name": "biller", "resource_arn": False},
+        "fields @timestamp",
+        [("12:00", "boom")],
+        alert_time="2026-08-29 09:23:03 UTC",
+    )
+    assert "Alert Time: 2026-08-29 09:23:03 UTC" in str(stamped)
 
 
 def test_utc_now_format():

--- a/test_fireeye.py
+++ b/test_fireeye.py
@@ -10,7 +10,7 @@ from fireeye.cloudwatch import (
     quote,
 )
 from fireeye.exceptions import ARNFormatError, CloudWatchLogException
-from fireeye.slack import create_payload, format_matches
+from fireeye.slack import create_payload, format_matches, utc_now
 
 
 def test_parse_arn():
@@ -107,6 +107,22 @@ def test_create_payload():
     body = payload["blocks"][-1]["text"]["text"]
     assert "boom" in body and "fields @timestamp" in body
     assert "Resource ARN: none" in str(payload)
+
+    # the alert carries its own send time, in UTC, not the log line timestamps
+    assert f"Alert Time: {utc_now()[:13]}" in str(payload)
+
+
+def test_utc_now_format():
+    import datetime
+    import re
+
+    stamp = utc_now()
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC", stamp), stamp
+
+    # within a minute of actual UTC, so a local-time clock would not pass
+    parsed = datetime.datetime.strptime(stamp, "%Y-%m-%d %H:%M:%S UTC")
+    now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+    assert abs((now - parsed).total_seconds()) < 60
 
 
 class FakeLogs:


### PR DESCRIPTION
A Slack alert carried the account ID, resource ARN and resource name, but nothing about when it fired. The log line timestamps in the body come from CloudWatch and answer a different question: an alert can arrive well after the lines it reports, and on a schedule it usually does.

The header block now reads:

```
Account ID: 123456789012
Resource ARN: none
Resource Name: example-fn
Alert Time: 2026-08-29 09:23:03 UTC
```

UTC rather than local time, so it reads the same for whoever is on call and does not shift with the machine running the job. `utc_now()` builds it from an aware UTC datetime rather than `datetime.now()`, which would silently be local.

### Verified
Sent through a real incoming webhook: delivered, exit 0. The self-check gains a format assertion and a check that the value tracks actual UTC within a minute, which a local-time clock would fail in any non-zero offset. Confirmed by running under `TZ=Asia/Kolkata`: local 14:53:03, alert time 09:23:03 UTC. 11 checks pass.