### PR TITLE
Document testing against a local CloudWatch with MiniStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,61 @@ python3 test_fireeye.py
 No test framework needed. The checks cover ARN parsing, query building and escaping, result handling,
 and the Slack payload, and they make no AWS calls.
 
+##### Testing against a local AWS
+
+[MiniStack](https://github.com/ministackorg/ministack) emulates CloudWatch Logs locally, so the AWS
+paths can be exercised without touching a real account or paying for Logs Insights scans. It is pure
+Python and needs no Docker.
+
+```bash
+pip install ministack
+ministack -d          # starts on port 4566, `ministack --stop` to stop
+```
+
+Seed a log group with a Lambda stream and an EC2 style stream:
+
+```python
+import time, boto3
+
+logs = boto3.client(
+    "logs", region_name="us-east-1", endpoint_url="http://127.0.0.1:4566",
+    aws_access_key_id="test", aws_secret_access_key="test",
+)
+group = "/aws/lambda/example-fn"
+logs.create_log_group(logGroupName=group)
+
+now = int(time.time() * 1000)
+for stream, events in {
+    "2026/01/01/[$LATEST]aaaa": ["REPORT RequestId: 1111\tDuration: 514.37 ms", "ERROR exploded"],
+    "i-0abc1234": ["kernel: Out of memory: Killed process 999"],
+}.items():
+    logs.create_log_stream(logGroupName=group, logStreamName=stream)
+    logs.put_log_events(
+        logGroupName=group, logStreamName=stream,
+        logEvents=[{"timestamp": now - 1000 * i, "message": m} for i, m in enumerate(events)],
+    )
+```
+
+Point FireEye at it with `AWS_ENDPOINT_URL` and any non-empty credentials:
+
+```bash
+export AWS_ENDPOINT_URL=http://127.0.0.1:4566
+export AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1
+
+fireeye --resource-name example-fn --trace ERROR --regex
+fireeye --resource-name i-0abc1234 --log-group /aws/lambda/example-fn --trace '(?i)out of memory' --regex
+```
+
+Two differences from real CloudWatch are worth knowing before you trust a result:
+
+- MiniStack does not apply `filter @message like "text"`, the quoted form, and returns every event
+  instead. The regex form, `like /text/`, filters correctly. So use `--regex` locally. Real
+  CloudWatch filters both, verified against a live account.
+- A query run immediately after seeding can come back empty. Retry before believing it.
+
+MiniStack cannot tell you whether a CloudWatch agent on a real instance names its streams after the
+instance ID. That is a matter of how the agent is configured, not something the code decides.
+
 ### To Do
 
 - [x] EC2 Log Monitoring


### PR DESCRIPTION
Writes up the local setup used to test the AWS paths through this session, so it does not live only in one person's shell history.

Covers installing and starting [MiniStack](https://github.com/ministackorg/ministack) (pure Python, no Docker, port 4566), seeding a log group with a Lambda style stream and an `i-0abc1234` stream, and pointing FireEye at it with `AWS_ENDPOINT_URL` plus placeholder credentials. Running against a local emulator means no Logs Insights scan charges and no dependence on what happens to exist in an account.

Two behaviours are called out because they will otherwise cost someone an afternoon:

- MiniStack does not apply the quoted filter form, `filter @message like "text"`, and returns every event in the group. The regex form filters correctly, so `--regex` is the one to use locally. Real CloudWatch filters both, which I verified against a live account.
- A query run immediately after seeding can come back empty and then succeed on retry. Hit this twice while writing this up.

Also notes the limit: MiniStack says nothing about whether a real CloudWatch agent names its streams after the instance ID, which is agent configuration rather than anything the code decides.

### Verified
The Python seed block was extracted from the README and run verbatim against a fresh group, then both documented commands were run against it. The Lambda search returns the seeded ERROR line; the EC2 command returns the seeded kernel line, empty on the first attempt and consistent on retry, which is the flakiness the section warns about.