### PR TITLE
Note what EC2 instance scoping assumes about stream names

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ Logs are scoped to the streams belonging to the instance.
 fireeye --trace "Out of memory" --resource-name i-0abc1234 --log-group /var/log/syslog
 ```
 
+Instance scoping assumes the CloudWatch agent writes one stream per instance named after the
+instance ID, which is what `"log_stream_name": "{instance_id}"` produces. Verified against agent
+1.300069.1 on Amazon Linux 2023.
+
+If your agent uses something else, `{hostname}` or a fixed string, then `--resource-name i-0abc1234`
+matches no streams and returns nothing. FireEye cannot tell that apart from a search that genuinely
+found no lines. Search the group directly instead, which reads every stream in it:
+
+```bash
+fireeye --trace "Out of memory" --resource-name /var/log/syslog
+```
+
+Check what your agent is doing with `aws logs describe-log-streams --log-group-name <group>`.
+
 ##### Search
 
 `--trace` is a plain substring match by default. Pass `--regex` to use a CloudWatch regex


### PR DESCRIPTION
Came out of testing the EC2 path against a real instance rather than an emulator.

`--resource-name i-0abc1234` adds `filter @logStream like "i-0abc1234"` to the query. That works when the CloudWatch agent names one stream per instance after the instance ID, which `"log_stream_name": "{instance_id}"` produces. Confirmed against agent 1.300069.1 on Amazon Linux 2023: the agent created a stream named exactly `i-0abc1234`-style and the search returned the seeded line.

The gap is what happens when someone configures their agent differently, `{hostname}` or a fixed string. The filter then matches no streams and FireEye reports nothing found, which looks identical to a search that legitimately found nothing. Nothing in the output hints that the scoping itself was the problem.

So the section now says what the assumption is, what to do instead (`--resource-name <log group>`, which reads every stream in the group), and how to check (`aws logs describe-log-streams`).

Documentation only, no code change. I considered detecting the mismatch by listing streams before querying, and decided against it: an extra `DescribeLogStreams` call on every EC2 run to catch a deliberate configuration choice is not worth it.

17 checks pass.