### PR TITLE
Build a wheel as well as an sdist

### DIFF
--- a/.github/workflows/pypi-publish-workflow.yml
+++ b/.github/workflows/pypi-publish-workflow.yml
@@ -14,7 +14,9 @@ jobs:
         with:
           python-version: 3.11
       - name: Build
-        run: python setup.py sdist
+        run: |
+          python -m pip install --upgrade build
+          python -m build
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           retention-days: 1


### PR DESCRIPTION
Worth doing before 0.7.0 goes out, since a version number on PyPI is permanent and the artifacts published under it cannot be changed later.

`python setup.py sdist` produces a source distribution only. Every `pip install FireEye-AWS` then builds from source, which is slower and depends on the installing machine having a working build toolchain. `python -m build` produces both a wheel and an sdist, and it goes through PEP 517 rather than invoking `setup.py` directly, which setuptools has been deprecating for some time.

```yaml
- name: Build
  run: |
    python -m pip install --upgrade build
    python -m build
```

The rest of the workflow is unchanged: the artifact upload already takes everything in `dist/`, and `gh-action-pypi-publish` uploads whatever it finds there.

### Verified
Built locally against this branch: `fireeye_aws-0.7.0-py3-none-any.whl` and `fireeye_aws-0.7.0.tar.gz`. Installed the wheel into a clean venv, boto3 resolved, and the CLI ran against a real log group with exit 0. Note that `build` builds the wheel from the sdist, so this also confirms the sdist carries everything the build needs, including `README.md` for `long_description` and `fireeye/__init__.py` for the version.