### PR TITLE
Guard the version before building, publish on release

### DIFF
--- a/.github/check_version.py
+++ b/.github/check_version.py
@@ -1,0 +1,51 @@
+"""Fail before building if the version cannot be published.
+
+Two ways a release goes wrong late: the version was never bumped, so PyPI
+rejects the upload as a duplicate after the build has already run; or the git
+tag says one thing and fireeye/__init__.py says another, so the wrong number
+ships under the right tag.
+"""
+
+import json
+import os
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+
+PROJECT = "FireEye-AWS"
+
+
+def package_version():
+    init = pathlib.Path(__file__).resolve().parents[1] / "fireeye" / "__init__.py"
+    for line in init.read_text().splitlines():
+        if line.startswith("__version__"):
+            return line.split('"')[1]
+
+    sys.exit("no __version__ in fireeye/__init__.py")
+
+
+def published_versions():
+    url = f"https://pypi.org/pypi/{PROJECT}/json"
+    try:
+        with urllib.request.urlopen(url, timeout=30) as r:
+            return set(json.load(r)["releases"])
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return set()  # nothing published yet
+        raise
+
+
+version = package_version()
+tag = os.environ.get("RELEASE_TAG", "")
+
+if tag and tag.lstrip("v") != version:
+    sys.exit(f"tag {tag} does not match fireeye.__version__ {version}")
+
+if version in published_versions():
+    sys.exit(
+        f"{PROJECT} {version} is already on PyPI. Bump __version__ in "
+        f"fireeye/__init__.py; PyPI never accepts a version twice."
+    )
+
+print(f"{version} is not on PyPI yet" + (f" and matches tag {tag}" if tag else ""))

--- a/.github/workflows/pypi-publish-workflow.yml
+++ b/.github/workflows/pypi-publish-workflow.yml
@@ -1,6 +1,8 @@
 name: pypi-publish-workflow.yml
 on:
   workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -13,6 +15,10 @@ jobs:
       - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: 3.11
+      - name: Check the version is releasable
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: python .github/check_version.py
       - name: Build
         run: |
           python -m pip install --upgrade build


### PR DESCRIPTION
Closes the two gaps left after 0.7.0 went out.

### A missed version bump failed late
Nothing checked whether the version was publishable, so forgetting to bump `fireeye/__init__.py` surfaced as a rejection from PyPI after the build had already run. `.github/check_version.py` runs as the first step and says what to do:

```
FireEye-AWS 0.7.0 is already on PyPI. Bump __version__ in fireeye/__init__.py;
PyPI never accepts a version twice.
```

### The tag and the shipped version could disagree
The workflow now also triggers on `release: types: [published]`, so creating a GitHub release publishes to PyPI and the two cannot drift. When it runs that way the guard additionally requires the tag to match `__version__`, because the tag is what people read on the releases page and the file is what actually ships:

```
tag v0.9.9 does not match fireeye.__version__ 0.7.0
```

`workflow_dispatch` still works for a manual publish. There is no tag then, so only the duplicate check applies.

### Verified
All four paths exercised locally against the live PyPI API:

| Case | Result |
| --- | --- |
| 0.7.0, already published | exit 1, duplicate message |
| 0.7.0 with tag v0.9.9 | exit 1, mismatch message |
| 0.8.0, unpublished, no tag | exit 0 |
| 0.8.0 with tag v0.8.0 | exit 0 |
| 0.8.0 with tag v0.8.1 | exit 1, mismatch message |

Standard library only, no new dependency. A 404 from PyPI is treated as nothing published yet rather than an error.