### PR TITLE
Fix the logo on PyPI, bump to 0.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-    <a href="https://github.com/r0075h3ll/FireEye"><img alt="FireEye" src="/static/logo/fireeye.png" width="100"/></a>
+    <a href="https://github.com/r0075h3ll/FireEye"><img alt="FireEye" src="https://raw.githubusercontent.com/r0075h3ll/FireEye/main/static/logo/fireeye.png" width="100"/></a>
     <h2>
     FireEye
     </h2>
@@ -10,7 +10,7 @@
 <div align="center">
 <img src="https://img.shields.io/badge/License-Apache%202.0-blue">
 <img src="https://img.shields.io/badge/Python-3.12-blue">
-<img src="https://img.shields.io/badge/Release-0.7.0-green">
+<img src="https://img.shields.io/badge/Release-0.7.1-green">
 </div>
 
 \
@@ -139,6 +139,14 @@ python3 test_fireeye.py
 
 No test framework needed. The checks cover ARN parsing, query building and escaping, result handling,
 and the Slack payload, and they make no AWS calls.
+
+Packaging is declared in `pyproject.toml`, and the version comes from `fireeye.__version__`. To build
+the distributions locally:
+
+```bash
+pip install build
+python -m build
+```
 
 ##### Testing against a local AWS
 

--- a/fireeye/__init__.py
+++ b/fireeye/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 
 def banner():


### PR DESCRIPTION
### The logo was broken on PyPI
The README used `src="/static/logo/fireeye.png"`. GitHub rewrites a root-relative path to `/r0075h3ll/FireEye/raw/main/...` when rendering, so it always looked right there. PyPI has no repository context, so the path resolved against `pypi.org` and 404'd.

Rendering the README through `readme_renderer`, which is what PyPI itself uses, shows exactly that:

```
old: <img alt="FireEye" src="/static/logo/fireeye.png" width="100">
new: <img alt="FireEye" src="https://raw.githubusercontent.com/r0075h3ll/FireEye/main/static/logo/fireeye.png" width="100">
```

The tag was never stripped by the sanitizer, so it rendered as a broken image rather than nothing. The absolute URL works in both places, and the file serves `200 image/png`, 7109 bytes.

### 0.7.1
Nothing under `fireeye/` has changed since `0.7.0` was published (`git diff 6eada9b..main -- fireeye/` is empty). This release carries the wheel build (#17), the version guard (#18) and `pyproject.toml` (#19), all packaging, plus this README fix. A patch bump, not a minor one.

Badge updated to match, and the Development section now says how to build locally, since `setup.py` is gone.

### Verified
`check_version.py` passes for 0.7.1 both with and without `RELEASE_TAG=v0.7.1`. `python -m build` produces `fireeye_aws-0.7.1` in both formats, `twine check` passes on both, and the 17 self-checks pass.